### PR TITLE
Revert changes that depend on Java 11+

### DIFF
--- a/src/main/java/org/w3id/cwl/cwl1_2/utils/Loader.java
+++ b/src/main/java/org/w3id/cwl/cwl1_2/utils/Loader.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 public interface Loader<T> {
 
-  abstract T load(
+  T load(
       final Object doc,
       final String baseUri,
       final LoadingOptions loadingOptions,
@@ -85,7 +85,7 @@ public interface Loader<T> {
     return load(val, baseUri, loadingOptions);
   }
 
-  private Map<String, Object> copyWithoutKey(final Map<String, Object> doc, final String key) {
+  default Map<String, Object> copyWithoutKey(final Map<String, Object> doc, final String key) {
     final Map<String, Object> result = new HashMap();
     for (final Map.Entry<String, Object> entry : doc.entrySet()) {
       if (!entry.getKey().equals(key)) {
@@ -95,7 +95,7 @@ public interface Loader<T> {
     return result;
   }
 
-  public static <T> T validateOfJavaType(final Class<T> clazz, final Object doc) {
+  static <T> T validateOfJavaType(final Class<T> clazz, final Object doc) {
     if (!clazz.isInstance(doc)) {
       String className = "null";
       if (doc != null) {


### PR DESCRIPTION
In Java 8, neither `private` nor `public static` methods are allowed on interfaces. Making these few changes makes it possible to compile cwLjava on Java 8 once again.

It would also be nice to add these lines to pom.xml to ensure Java 8 compatibility:

```
<project>
    <properties>
        <maven.compiler.source>8</maven.compiler.source>
        <maven.compiler.target>8</maven.compiler.target>
        ...
```