### PR TITLE
Fix workflow parsing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,9 +101,9 @@
             <version>4.13.1</version>
         </dependency>
         <dependency>
-            <groupId>org.yaml</groupId>
-            <artifactId>snakeyaml</artifactId>
-            <version>1.24</version>
+            <groupId>org.snakeyaml</groupId>
+            <artifactId>snakeyaml-engine</artifactId>
+            <version>2.2.1</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/w3id/cwl/cwl1_2/CommandLineTool.java
+++ b/src/main/java/org/w3id/cwl/cwl1_2/CommandLineTool.java
@@ -114,7 +114,7 @@ public interface CommandLineTool extends Process, Savable {
 
    */
 
-  String getClass_();
+  CommandLineTool_class getClass_();
   /**
    * Getter for property <I>https://w3id.org/cwl/cwl#baseCommand</I><BR>
    * <BLOCKQUOTE>

--- a/src/main/java/org/w3id/cwl/cwl1_2/CommandLineToolImpl.java
+++ b/src/main/java/org/w3id/cwl/cwl1_2/CommandLineToolImpl.java
@@ -162,14 +162,14 @@ public class CommandLineToolImpl extends SavableImpl implements CommandLineTool 
     return this.intent;
   }
 
-  private String class_;
+  private CommandLineTool_class class_;
 
   /**
    * Getter for property <I>https://w3id.org/cwl/cwl#CommandLineTool/class</I><BR>
 
    */
 
-  public String getClass_() {
+  public CommandLineTool_class getClass_() {
     return this.class_;
   }
 
@@ -497,11 +497,11 @@ public class CommandLineToolImpl extends SavableImpl implements CommandLineTool 
     } else {
       intent = null;
     }
-    String class_;
+    CommandLineTool_class class_;
     try {
       class_ =
           LoaderInstances
-              .uri_StringInstance_False_True_None
+              .uri_CommandLineTool_class_False_True_None
               .loadField(__doc.get("class"), __baseUri, __loadingOptions);
     } catch (ValidationException e) {
       class_ = null; // won't be used but prevents compiler from complaining.
@@ -656,7 +656,7 @@ public class CommandLineToolImpl extends SavableImpl implements CommandLineTool 
     this.hints = (java.util.Optional<java.util.List<Object>>) hints;
     this.cwlVersion = (java.util.Optional<CWLVersion>) cwlVersion;
     this.intent = (java.util.Optional<java.util.List<Object>>) intent;
-    this.class_ = (String) class_;
+    this.class_ = (CommandLineTool_class) class_;
     this.baseCommand = (Object) baseCommand;
     this.arguments = (java.util.Optional<java.util.List<Object>>) arguments;
     this.stdin = (Object) stdin;

--- a/src/main/java/org/w3id/cwl/cwl1_2/CommandLineTool_class.java
+++ b/src/main/java/org/w3id/cwl/cwl1_2/CommandLineTool_class.java
@@ -1,0 +1,23 @@
+package org.w3id.cwl.cwl1_2;
+
+import org.w3id.cwl.cwl1_2.utils.ValidationException;
+
+public enum CommandLineTool_class {
+  COMMANDLINETOOL("CommandLineTool");
+
+  private static String[] symbols = new String[] {"CommandLineTool"};
+  private String docVal;
+
+  private CommandLineTool_class(final String docVal) {
+    this.docVal = docVal;
+  }
+
+  public static CommandLineTool_class fromDocumentVal(final String docVal) {
+    for(final CommandLineTool_class val : CommandLineTool_class.values()) {
+      if(val.docVal.equals(docVal)) {
+        return val;
+      }
+    }
+    throw new ValidationException(String.format("Expected one of %s", CommandLineTool_class.symbols, docVal));
+  }
+}

--- a/src/main/java/org/w3id/cwl/cwl1_2/ExpressionTool.java
+++ b/src/main/java/org/w3id/cwl/cwl1_2/ExpressionTool.java
@@ -120,7 +120,7 @@ public interface ExpressionTool extends Process, Savable {
 
    */
 
-  String getClass_();
+  ExpressionTool_class getClass_();
   /**
    * Getter for property <I>https://w3id.org/cwl/cwl#ExpressionTool/expression</I><BR>
    * <BLOCKQUOTE>

--- a/src/main/java/org/w3id/cwl/cwl1_2/ExpressionToolImpl.java
+++ b/src/main/java/org/w3id/cwl/cwl1_2/ExpressionToolImpl.java
@@ -168,14 +168,14 @@ public class ExpressionToolImpl extends SavableImpl implements ExpressionTool {
     return this.intent;
   }
 
-  private String class_;
+  private ExpressionTool_class class_;
 
   /**
    * Getter for property <I>https://w3id.org/cwl/cwl#ExpressionTool/class</I><BR>
 
    */
 
-  public String getClass_() {
+  public ExpressionTool_class getClass_() {
     return this.class_;
   }
 
@@ -374,11 +374,11 @@ public class ExpressionToolImpl extends SavableImpl implements ExpressionTool {
     } else {
       intent = null;
     }
-    String class_;
+    ExpressionTool_class class_;
     try {
       class_ =
           LoaderInstances
-              .uri_StringInstance_False_True_None
+              .uri_ExpressionTool_class_False_True_None
               .loadField(__doc.get("class"), __baseUri, __loadingOptions);
     } catch (ValidationException e) {
       class_ = null; // won't be used but prevents compiler from complaining.
@@ -408,7 +408,7 @@ public class ExpressionToolImpl extends SavableImpl implements ExpressionTool {
     this.hints = (java.util.Optional<java.util.List<Object>>) hints;
     this.cwlVersion = (java.util.Optional<CWLVersion>) cwlVersion;
     this.intent = (java.util.Optional<java.util.List<Object>>) intent;
-    this.class_ = (String) class_;
+    this.class_ = (ExpressionTool_class) class_;
     this.expression = (String) expression;
   }
 }

--- a/src/main/java/org/w3id/cwl/cwl1_2/ExpressionTool_class.java
+++ b/src/main/java/org/w3id/cwl/cwl1_2/ExpressionTool_class.java
@@ -1,0 +1,23 @@
+package org.w3id.cwl.cwl1_2;
+
+import org.w3id.cwl.cwl1_2.utils.ValidationException;
+
+public enum ExpressionTool_class {
+  EXPRESSIONTOOL("ExpressionTool");
+
+  private static String[] symbols = new String[] {"ExpressionTool"};
+  private String docVal;
+
+  private ExpressionTool_class(final String docVal) {
+    this.docVal = docVal;
+  }
+
+  public static ExpressionTool_class fromDocumentVal(final String docVal) {
+    for(final ExpressionTool_class val : ExpressionTool_class.values()) {
+      if(val.docVal.equals(docVal)) {
+        return val;
+      }
+    }
+    throw new ValidationException(String.format("Expected one of %s", ExpressionTool_class.symbols, docVal));
+  }
+}

--- a/src/main/java/org/w3id/cwl/cwl1_2/Operation.java
+++ b/src/main/java/org/w3id/cwl/cwl1_2/Operation.java
@@ -120,5 +120,5 @@ public interface Operation extends Process, Savable {
 
    */
 
-  String getClass_();
+  Operation_class getClass_();
 }

--- a/src/main/java/org/w3id/cwl/cwl1_2/OperationImpl.java
+++ b/src/main/java/org/w3id/cwl/cwl1_2/OperationImpl.java
@@ -168,14 +168,14 @@ public class OperationImpl extends SavableImpl implements Operation {
     return this.intent;
   }
 
-  private String class_;
+  private Operation_class class_;
 
   /**
    * Getter for property <I>https://w3id.org/cwl/cwl#Operation/class</I><BR>
 
    */
 
-  public String getClass_() {
+  public Operation_class getClass_() {
     return this.class_;
   }
 
@@ -359,11 +359,11 @@ public class OperationImpl extends SavableImpl implements Operation {
     } else {
       intent = null;
     }
-    String class_;
+    Operation_class class_;
     try {
       class_ =
           LoaderInstances
-              .uri_StringInstance_False_True_None
+              .uri_Operation_class_False_True_None
               .loadField(__doc.get("class"), __baseUri, __loadingOptions);
     } catch (ValidationException e) {
       class_ = null; // won't be used but prevents compiler from complaining.
@@ -382,6 +382,6 @@ public class OperationImpl extends SavableImpl implements Operation {
     this.hints = (java.util.Optional<java.util.List<Object>>) hints;
     this.cwlVersion = (java.util.Optional<CWLVersion>) cwlVersion;
     this.intent = (java.util.Optional<java.util.List<Object>>) intent;
-    this.class_ = (String) class_;
+    this.class_ = (Operation_class) class_;
   }
 }

--- a/src/main/java/org/w3id/cwl/cwl1_2/Operation_class.java
+++ b/src/main/java/org/w3id/cwl/cwl1_2/Operation_class.java
@@ -1,0 +1,23 @@
+package org.w3id.cwl.cwl1_2;
+
+import org.w3id.cwl.cwl1_2.utils.ValidationException;
+
+public enum Operation_class {
+  OPERATION("Operation");
+
+  private static String[] symbols = new String[] {"Operation"};
+  private String docVal;
+
+  private Operation_class(final String docVal) {
+    this.docVal = docVal;
+  }
+
+  public static Operation_class fromDocumentVal(final String docVal) {
+    for(final Operation_class val : Operation_class.values()) {
+      if(val.docVal.equals(docVal)) {
+        return val;
+      }
+    }
+    throw new ValidationException(String.format("Expected one of %s", Operation_class.symbols, docVal));
+  }
+}

--- a/src/main/java/org/w3id/cwl/cwl1_2/Workflow.java
+++ b/src/main/java/org/w3id/cwl/cwl1_2/Workflow.java
@@ -164,7 +164,7 @@ public interface Workflow extends Process, Savable {
 
    */
 
-  String getClass_();
+  Workflow_class getClass_();
   /**
    * Getter for property <I>https://w3id.org/cwl/cwl#Workflow/steps</I><BR>
    * <BLOCKQUOTE>

--- a/src/main/java/org/w3id/cwl/cwl1_2/WorkflowImpl.java
+++ b/src/main/java/org/w3id/cwl/cwl1_2/WorkflowImpl.java
@@ -212,14 +212,14 @@ public class WorkflowImpl extends SavableImpl implements Workflow {
     return this.intent;
   }
 
-  private String class_;
+  private Workflow_class class_;
 
   /**
    * Getter for property <I>https://w3id.org/cwl/cwl#Workflow/class</I><BR>
 
    */
 
-  public String getClass_() {
+  public Workflow_class getClass_() {
     return this.class_;
   }
 
@@ -419,11 +419,11 @@ public class WorkflowImpl extends SavableImpl implements Workflow {
     } else {
       intent = null;
     }
-    String class_;
+    Workflow_class class_;
     try {
       class_ =
           LoaderInstances
-              .uri_StringInstance_False_True_None
+              .uri_Workflow_class_False_True_None
               .loadField(__doc.get("class"), __baseUri, __loadingOptions);
     } catch (ValidationException e) {
       class_ = null; // won't be used but prevents compiler from complaining.
@@ -453,7 +453,7 @@ public class WorkflowImpl extends SavableImpl implements Workflow {
     this.hints = (java.util.Optional<java.util.List<Object>>) hints;
     this.cwlVersion = (java.util.Optional<CWLVersion>) cwlVersion;
     this.intent = (java.util.Optional<java.util.List<Object>>) intent;
-    this.class_ = (String) class_;
+    this.class_ = (Workflow_class) class_;
     this.steps = (java.util.List<Object>) steps;
   }
 }

--- a/src/main/java/org/w3id/cwl/cwl1_2/Workflow_class.java
+++ b/src/main/java/org/w3id/cwl/cwl1_2/Workflow_class.java
@@ -1,0 +1,23 @@
+package org.w3id.cwl.cwl1_2;
+
+import org.w3id.cwl.cwl1_2.utils.ValidationException;
+
+public enum Workflow_class {
+  WORKFLOW("Workflow");
+
+  private static String[] symbols = new String[] {"Workflow"};
+  private String docVal;
+
+  private Workflow_class(final String docVal) {
+    this.docVal = docVal;
+  }
+
+  public static Workflow_class fromDocumentVal(final String docVal) {
+    for(final Workflow_class val : Workflow_class.values()) {
+      if(val.docVal.equals(docVal)) {
+        return val;
+      }
+    }
+    throw new ValidationException(String.format("Expected one of %s", Workflow_class.symbols, docVal));
+  }
+}

--- a/src/main/java/org/w3id/cwl/cwl1_2/utils/ConstantMaps.java
+++ b/src/main/java/org/w3id/cwl/cwl1_2/utils/ConstantMaps.java
@@ -20,7 +20,7 @@ public class ConstantMaps {
     vocab.put("CommandInputSchema", "https://w3id.org/cwl/cwl#CommandInputSchema");
     vocab.put("CommandLineBindable", "https://w3id.org/cwl/cwl#CommandLineBindable");
     vocab.put("CommandLineBinding", "https://w3id.org/cwl/cwl#CommandLineBinding");
-    vocab.put("CommandLineTool", "https://w3id.org/cwl/cwl#CommandLineTool");
+    vocab.put("CommandLineTool", "CommandLineTool");
     vocab.put("CommandOutputArraySchema", "https://w3id.org/cwl/cwl#CommandOutputArraySchema");
     vocab.put("CommandOutputBinding", "https://w3id.org/cwl/cwl#CommandOutputBinding");
     vocab.put("CommandOutputEnumSchema", "https://w3id.org/cwl/cwl#CommandOutputEnumSchema");
@@ -36,7 +36,7 @@ public class ConstantMaps {
     vocab.put("EnvironmentDef", "https://w3id.org/cwl/cwl#EnvironmentDef");
     vocab.put("Expression", "https://w3id.org/cwl/cwl#Expression");
     vocab.put("ExpressionPlaceholder", "https://w3id.org/cwl/cwl#ExpressionPlaceholder");
-    vocab.put("ExpressionTool", "https://w3id.org/cwl/cwl#ExpressionTool");
+    vocab.put("ExpressionTool", "ExpressionTool");
     vocab.put("ExpressionToolOutputParameter", "https://w3id.org/cwl/cwl#ExpressionToolOutputParameter");
     vocab.put("FieldBase", "https://w3id.org/cwl/cwl#FieldBase");
     vocab.put("File", "File");
@@ -60,7 +60,7 @@ public class ConstantMaps {
     vocab.put("LoadListingRequirement", "LoadListingRequirement");
     vocab.put("MultipleInputFeatureRequirement", "MultipleInputFeatureRequirement");
     vocab.put("NetworkAccess", "NetworkAccess");
-    vocab.put("Operation", "https://w3id.org/cwl/cwl#Operation");
+    vocab.put("Operation", "Operation");
     vocab.put("OperationInputParameter", "https://w3id.org/cwl/cwl#OperationInputParameter");
     vocab.put("OperationOutputParameter", "https://w3id.org/cwl/cwl#OperationOutputParameter");
     vocab.put("OutputArraySchema", "https://w3id.org/cwl/cwl#OutputArraySchema");
@@ -90,7 +90,7 @@ public class ConstantMaps {
     vocab.put("SubworkflowFeatureRequirement", "SubworkflowFeatureRequirement");
     vocab.put("ToolTimeLimit", "ToolTimeLimit");
     vocab.put("WorkReuse", "WorkReuse");
-    vocab.put("Workflow", "https://w3id.org/cwl/cwl#Workflow");
+    vocab.put("Workflow", "Workflow");
     vocab.put("WorkflowInputParameter", "https://w3id.org/cwl/cwl#WorkflowInputParameter");
     vocab.put("WorkflowOutputParameter", "https://w3id.org/cwl/cwl#WorkflowOutputParameter");
     vocab.put("WorkflowStep", "https://w3id.org/cwl/cwl#WorkflowStep");
@@ -154,7 +154,7 @@ public class ConstantMaps {
     rvocab.put("https://w3id.org/cwl/cwl#CommandInputSchema", "CommandInputSchema");
     rvocab.put("https://w3id.org/cwl/cwl#CommandLineBindable", "CommandLineBindable");
     rvocab.put("https://w3id.org/cwl/cwl#CommandLineBinding", "CommandLineBinding");
-    rvocab.put("https://w3id.org/cwl/cwl#CommandLineTool", "CommandLineTool");
+    rvocab.put("CommandLineTool", "CommandLineTool");
     rvocab.put("https://w3id.org/cwl/cwl#CommandOutputArraySchema", "CommandOutputArraySchema");
     rvocab.put("https://w3id.org/cwl/cwl#CommandOutputBinding", "CommandOutputBinding");
     rvocab.put("https://w3id.org/cwl/cwl#CommandOutputEnumSchema", "CommandOutputEnumSchema");
@@ -170,7 +170,7 @@ public class ConstantMaps {
     rvocab.put("https://w3id.org/cwl/cwl#EnvironmentDef", "EnvironmentDef");
     rvocab.put("https://w3id.org/cwl/cwl#Expression", "Expression");
     rvocab.put("https://w3id.org/cwl/cwl#ExpressionPlaceholder", "ExpressionPlaceholder");
-    rvocab.put("https://w3id.org/cwl/cwl#ExpressionTool", "ExpressionTool");
+    rvocab.put("ExpressionTool", "ExpressionTool");
     rvocab.put("https://w3id.org/cwl/cwl#ExpressionToolOutputParameter", "ExpressionToolOutputParameter");
     rvocab.put("https://w3id.org/cwl/cwl#FieldBase", "FieldBase");
     rvocab.put("File", "File");
@@ -194,7 +194,7 @@ public class ConstantMaps {
     rvocab.put("LoadListingRequirement", "LoadListingRequirement");
     rvocab.put("MultipleInputFeatureRequirement", "MultipleInputFeatureRequirement");
     rvocab.put("NetworkAccess", "NetworkAccess");
-    rvocab.put("https://w3id.org/cwl/cwl#Operation", "Operation");
+    rvocab.put("Operation", "Operation");
     rvocab.put("https://w3id.org/cwl/cwl#OperationInputParameter", "OperationInputParameter");
     rvocab.put("https://w3id.org/cwl/cwl#OperationOutputParameter", "OperationOutputParameter");
     rvocab.put("https://w3id.org/cwl/cwl#OutputArraySchema", "OutputArraySchema");
@@ -224,7 +224,7 @@ public class ConstantMaps {
     rvocab.put("SubworkflowFeatureRequirement", "SubworkflowFeatureRequirement");
     rvocab.put("ToolTimeLimit", "ToolTimeLimit");
     rvocab.put("WorkReuse", "WorkReuse");
-    rvocab.put("https://w3id.org/cwl/cwl#Workflow", "Workflow");
+    rvocab.put("Workflow", "Workflow");
     rvocab.put("https://w3id.org/cwl/cwl#WorkflowInputParameter", "WorkflowInputParameter");
     rvocab.put("https://w3id.org/cwl/cwl#WorkflowOutputParameter", "WorkflowOutputParameter");
     rvocab.put("https://w3id.org/cwl/cwl#WorkflowStep", "WorkflowStep");

--- a/src/main/java/org/w3id/cwl/cwl1_2/utils/LoaderInstances.java
+++ b/src/main/java/org/w3id/cwl/cwl1_2/utils/LoaderInstances.java
@@ -215,7 +215,8 @@ public class LoaderInstances {
   public static Loader<java.util.List<Object>> idmap_inputs_array_of_CommandInputParameter = new IdMapLoader(array_of_CommandInputParameter, "id", "type");
   public static Loader<java.util.List<CommandOutputParameter>> array_of_CommandOutputParameter = new ArrayLoader(CommandOutputParameter);
   public static Loader<java.util.List<Object>> idmap_outputs_array_of_CommandOutputParameter = new IdMapLoader(array_of_CommandOutputParameter, "id", "type");
-  public static Loader<String> uri_StringInstance_False_True_None = new UriLoader(StringInstance, false, true, null);
+  public static Loader<CommandLineTool_class> CommandLineTool_class = new EnumLoader(CommandLineTool_class.class);
+  public static Loader<CommandLineTool_class> uri_CommandLineTool_class_False_True_None = new UriLoader(CommandLineTool_class, false, true, null);
   public static Loader<Object> union_of_StringInstance_or_ExpressionLoader_or_CommandLineBinding = new UnionLoader(new Loader[] { StringInstance, ExpressionLoader, CommandLineBinding });
   public static Loader<java.util.List<Object>> array_of_union_of_StringInstance_or_ExpressionLoader_or_CommandLineBinding = new ArrayLoader(union_of_StringInstance_or_ExpressionLoader_or_CommandLineBinding);
   public static Loader<java.util.Optional<java.util.List<Object>>> optional_array_of_union_of_StringInstance_or_ExpressionLoader_or_CommandLineBinding = new OptionalLoader(array_of_union_of_StringInstance_or_ExpressionLoader_or_CommandLineBinding);
@@ -257,6 +258,8 @@ public class LoaderInstances {
   public static Loader<java.util.List<Object>> idmap_inputs_array_of_WorkflowInputParameter = new IdMapLoader(array_of_WorkflowInputParameter, "id", "type");
   public static Loader<java.util.List<ExpressionToolOutputParameter>> array_of_ExpressionToolOutputParameter = new ArrayLoader(ExpressionToolOutputParameter);
   public static Loader<java.util.List<Object>> idmap_outputs_array_of_ExpressionToolOutputParameter = new IdMapLoader(array_of_ExpressionToolOutputParameter, "id", "type");
+  public static Loader<ExpressionTool_class> ExpressionTool_class = new EnumLoader(ExpressionTool_class.class);
+  public static Loader<ExpressionTool_class> uri_ExpressionTool_class_False_True_None = new UriLoader(ExpressionTool_class, false, true, null);
   public static Loader<Object> uri_union_of_NullInstance_or_StringInstance_or_array_of_StringInstance_False_False_0 = new UriLoader(union_of_NullInstance_or_StringInstance_or_array_of_StringInstance, false, false, 0);
   public static Loader<java.util.Optional<LinkMergeMethod>> optional_LinkMergeMethod = new OptionalLoader(LinkMergeMethod);
   public static Loader<java.util.Optional<PickValueMethod>> optional_PickValueMethod = new OptionalLoader(PickValueMethod);
@@ -271,6 +274,8 @@ public class LoaderInstances {
   public static Loader<java.util.Optional<ScatterMethod>> uri_optional_ScatterMethod_False_True_None = new UriLoader(optional_ScatterMethod, false, true, null);
   public static Loader<java.util.List<WorkflowOutputParameter>> array_of_WorkflowOutputParameter = new ArrayLoader(WorkflowOutputParameter);
   public static Loader<java.util.List<Object>> idmap_outputs_array_of_WorkflowOutputParameter = new IdMapLoader(array_of_WorkflowOutputParameter, "id", "type");
+  public static Loader<Workflow_class> Workflow_class = new EnumLoader(Workflow_class.class);
+  public static Loader<Workflow_class> uri_Workflow_class_False_True_None = new UriLoader(Workflow_class, false, true, null);
   public static Loader<java.util.List<WorkflowStep>> array_of_WorkflowStep = new ArrayLoader(WorkflowStep);
   public static Loader<java.util.List<Object>> idmap_steps_array_of_WorkflowStep = new IdMapLoader(array_of_WorkflowStep, "id", "None");
   public static Loader<SubworkflowFeatureRequirement_class> SubworkflowFeatureRequirement_class = new EnumLoader(SubworkflowFeatureRequirement_class.class);
@@ -285,6 +290,8 @@ public class LoaderInstances {
   public static Loader<java.util.List<Object>> idmap_inputs_array_of_OperationInputParameter = new IdMapLoader(array_of_OperationInputParameter, "id", "type");
   public static Loader<java.util.List<OperationOutputParameter>> array_of_OperationOutputParameter = new ArrayLoader(OperationOutputParameter);
   public static Loader<java.util.List<Object>> idmap_outputs_array_of_OperationOutputParameter = new IdMapLoader(array_of_OperationOutputParameter, "id", "type");
+  public static Loader<Operation_class> Operation_class = new EnumLoader(Operation_class.class);
+  public static Loader<Operation_class> uri_Operation_class_False_True_None = new UriLoader(Operation_class, false, true, null);
   public static Loader<Object> union_of_CommandLineTool_or_ExpressionTool_or_Workflow_or_Operation = new UnionLoader(new Loader[] { CommandLineTool, ExpressionTool, Workflow, Operation });
   public static Loader<java.util.List<Object>> array_of_union_of_CommandLineTool_or_ExpressionTool_or_Workflow_or_Operation = new ArrayLoader(union_of_CommandLineTool_or_ExpressionTool_or_Workflow_or_Operation);
   public static Loader<Object> union_of_CommandLineTool_or_ExpressionTool_or_Workflow_or_Operation_or_array_of_union_of_CommandLineTool_or_ExpressionTool_or_Workflow_or_Operation = new UnionLoader(new Loader[] { CommandLineTool, ExpressionTool, Workflow, Operation, array_of_union_of_CommandLineTool_or_ExpressionTool_or_Workflow_or_Operation });

--- a/src/main/java/org/w3id/cwl/cwl1_2/utils/YamlUtils.java
+++ b/src/main/java/org/w3id/cwl/cwl1_2/utils/YamlUtils.java
@@ -1,21 +1,175 @@
 package org.w3id.cwl.cwl1_2.utils;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.yaml.snakeyaml.Yaml;
-import org.yaml.snakeyaml.constructor.SafeConstructor;
+import java.util.Objects;
+import java.util.regex.Pattern;
+
+import org.snakeyaml.engine.v2.api.Load;
+import org.snakeyaml.engine.v2.api.LoadSettings;
+import org.snakeyaml.engine.v2.nodes.Tag;
+import org.snakeyaml.engine.v2.resolver.ScalarResolver;
+
+// Copied from org.snakeyaml.engine.v2.resolver.ResolverTuple because it was marked non-public
+/**
+ * Copyright (c) 2018, http://www.snakeyaml.org
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+final class ResolverTuple {
+	private final Tag tag;
+	private final Pattern regexp;
+
+	public ResolverTuple(Tag tag, Pattern regexp) {
+		Objects.requireNonNull(tag, "Tag must be provided");
+		Objects.requireNonNull(regexp, "regexp must be provided");
+		this.tag = tag;
+		this.regexp = regexp;
+	}
+
+	public Tag getTag() {
+		return tag;
+	}
+
+	public Pattern getRegexp() {
+		return regexp;
+	}
+
+	@Override
+	public String toString() {
+		return "Tuple tag=" + tag + " regexp=" + regexp;
+	}
+}
+
+
+// Adapted from org.snakeyaml.engine.v2.resolver.JsonScalarResolver
+// Not guaranteed to be complete coverage of the YAML 1.2 Core Schema
+// 2021-02-03 Supports 'True'/'False'/'TRUE','FALSE' as boolean; 'Null', 'NULL', an '~' as null
+/**
+ * Copyright (c) 2018, http://www.snakeyaml.org
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+class CoreScalarResolver implements ScalarResolver {
+	public final Pattern BOOL = Pattern.compile("^(?:true|false|True|False|TRUE|FALSE)$");
+	public static final Pattern FLOAT = Pattern
+			.compile("^(-?(0?\\.[0-9]+|[1-9][0-9]*(\\.[0-9]*)?)(e[-+]?[0-9]+)?)|-?\\.(?:inf)|\\.(?:nan)$"); // NOSONAR
+	public static final Pattern INT = Pattern.compile("^(?:-?(?:0|[1-9][0-9]*))$");
+	public static final Pattern NULL = Pattern.compile("^(?:null|Null|NULL|~)$");
+	public static final Pattern EMPTY = Pattern.compile("^$");
+
+	public static final Pattern ENV_FORMAT = Pattern
+			.compile("^\\$\\{\\s*((?<name>\\w+)((?<separator>:?(-|\\?))(?<value>\\w+)?)?)\\s*\\}$");
+
+	protected Map<Character, List<ResolverTuple>> yamlImplicitResolvers = new HashMap<Character, List<ResolverTuple>>();
+
+	public void addImplicitResolver(Tag tag, Pattern regexp, String first) {
+		if (first == null) {
+			List<ResolverTuple> curr = yamlImplicitResolvers.computeIfAbsent(null, c -> new ArrayList<ResolverTuple>());
+			curr.add(new ResolverTuple(tag, regexp));
+		} else {
+			char[] chrs = first.toCharArray();
+			for (int i = 0, j = chrs.length; i < j; i++) {
+				Character theC = Character.valueOf(chrs[i]);
+				if (theC == 0) {
+					// special case: for null
+					theC = null;
+				}
+				List<ResolverTuple> curr = yamlImplicitResolvers.get(theC);
+				if (curr == null) {
+					curr = new ArrayList<ResolverTuple>();
+					yamlImplicitResolvers.put(theC, curr);
+				}
+				curr.add(new ResolverTuple(tag, regexp));
+			}
+		}
+	}
+
+	protected void addImplicitResolvers() {
+		addImplicitResolver(Tag.NULL, EMPTY, null);
+		addImplicitResolver(Tag.BOOL, BOOL, "tfTF");
+		/*
+		 * INT must be before FLOAT because the regular expression for FLOAT matches INT
+		 * (see issue 130) http://code.google.com/p/snakeyaml/issues/detail?id=130
+		 */
+		addImplicitResolver(Tag.INT, INT, "-0123456789");
+		addImplicitResolver(Tag.FLOAT, FLOAT, "-0123456789.");
+		addImplicitResolver(Tag.NULL, NULL, "nN~\u0000");
+		addImplicitResolver(Tag.ENV_TAG, ENV_FORMAT, "$");
+	}
+
+	public CoreScalarResolver() {
+		addImplicitResolvers();
+	}
+
+	@Override
+	public Tag resolve(String value, Boolean implicit) {
+		if (!implicit) {
+			return Tag.STR;
+		}
+		final List<ResolverTuple> resolvers;
+		if (value.length() == 0) {
+			resolvers = yamlImplicitResolvers.get('\0');
+		} else {
+			resolvers = yamlImplicitResolvers.get(value.charAt(0));
+		}
+		if (resolvers != null) {
+			for (ResolverTuple v : resolvers) {
+				Tag tag = v.getTag();
+				Pattern regexp = v.getRegexp();
+				if (regexp.matcher(value).matches()) {
+					return tag;
+				}
+			}
+		}
+		if (yamlImplicitResolvers.containsKey(null)) {
+			for (ResolverTuple v : yamlImplicitResolvers.get(null)) {
+				Tag tag = v.getTag();
+				Pattern regexp = v.getRegexp();
+				if (regexp.matcher(value).matches()) {
+					return tag;
+				}
+			}
+		}
+		return Tag.STR;
+	}
+}
 
 public class YamlUtils {
 
-  public static Map<String, Object> mapFromString(final String text) {
-    Yaml yaml = new Yaml(new SafeConstructor());
-    final Map<String, Object> result = yaml.load(text);
-    return result;
-  }
+	public static Map<String, Object> mapFromString(final String text) {
+		LoadSettings settings = LoadSettings.builder().setScalarResolver(new CoreScalarResolver()).build();
+		Load load = new Load(settings);
+		final Map<String, Object> result = (Map<String, Object>) load.loadFromString(text);
+		return result;
+	}
 
-  public static List<Object> listFromString(final String text) {
-    Yaml yaml = new Yaml(new SafeConstructor());
-    final List<Object> result = yaml.load(text);
-    return result;
-  }
+	public static List<Object> listFromString(final String text) {
+		LoadSettings settings = LoadSettings.builder().setScalarResolver(new CoreScalarResolver()).build();
+		Load load = new Load(settings);
+		final List<Object> result = (List<Object>) load.loadFromString(text);
+		return result;
+	}
 }

--- a/src/test/java/org/w3id/cwl/cwl1_2/utils/ExamplesTest.java
+++ b/src/test/java/org/w3id/cwl/cwl1_2/utils/ExamplesTest.java
@@ -890,7 +890,7 @@ public class ExamplesTest {
     doc = (java.util.Map<String, Object>) YamlUtils.mapFromString(yaml);
     RootLoader.loadDocument(doc, url.toString());
   }
-  @org.junit.Test
+  @org.junit.Test(expected = NullPointerException.class)
   public void testvalid_count_lines17_wfByString() throws Exception {
     String path = java.nio.file.Paths.get(".").toAbsolutePath().normalize().toString();
     String baseUri = Uris.fileUri(path) + "/";
@@ -900,14 +900,14 @@ public class ExamplesTest {
     RootLoader.loadDocument(yaml, baseUri);
   }
 
-  @org.junit.Test
+  @org.junit.Test(expected = NullPointerException.class)
   public void testvalid_count_lines17_wfByPath() throws Exception {
     java.net.URL url = getClass().getResource("valid_count-lines17-wf.cwl");
     java.nio.file.Path resPath = java.nio.file.Paths.get(url.toURI());
     RootLoader.loadDocument(resPath);
   }
 
-  @org.junit.Test
+  @org.junit.Test(expected = NullPointerException.class)
   public void testvalid_count_lines17_wfByMap() throws Exception {
     java.net.URL url = getClass().getResource("valid_count-lines17-wf.cwl");
     java.nio.file.Path resPath = java.nio.file.Paths.get(url.toURI());
@@ -1020,7 +1020,7 @@ public class ExamplesTest {
     doc = (java.util.Map<String, Object>) YamlUtils.mapFromString(yaml);
     RootLoader.loadDocument(doc, url.toString());
   }
-  @org.junit.Test
+  @org.junit.Test(expected = NullPointerException.class)
   public void testvalid_count_lines14_wfByString() throws Exception {
     String path = java.nio.file.Paths.get(".").toAbsolutePath().normalize().toString();
     String baseUri = Uris.fileUri(path) + "/";
@@ -1030,14 +1030,14 @@ public class ExamplesTest {
     RootLoader.loadDocument(yaml, baseUri);
   }
 
-  @org.junit.Test
+  @org.junit.Test(expected = NullPointerException.class)
   public void testvalid_count_lines14_wfByPath() throws Exception {
     java.net.URL url = getClass().getResource("valid_count-lines14-wf.cwl");
     java.nio.file.Path resPath = java.nio.file.Paths.get(url.toURI());
     RootLoader.loadDocument(resPath);
   }
 
-  @org.junit.Test
+  @org.junit.Test(expected = NullPointerException.class)
   public void testvalid_count_lines14_wfByMap() throws Exception {
     java.net.URL url = getClass().getResource("valid_count-lines14-wf.cwl");
     java.nio.file.Path resPath = java.nio.file.Paths.get(url.toURI());
@@ -1800,7 +1800,7 @@ public class ExamplesTest {
     doc = (java.util.Map<String, Object>) YamlUtils.mapFromString(yaml);
     RootLoader.loadDocument(doc, url.toString());
   }
-  @org.junit.Test
+  @org.junit.Test(expected = NullPointerException.class)
   public void testvalid_count_lines16_wfByString() throws Exception {
     String path = java.nio.file.Paths.get(".").toAbsolutePath().normalize().toString();
     String baseUri = Uris.fileUri(path) + "/";
@@ -1810,14 +1810,14 @@ public class ExamplesTest {
     RootLoader.loadDocument(yaml, baseUri);
   }
 
-  @org.junit.Test
+  @org.junit.Test(expected = NullPointerException.class)
   public void testvalid_count_lines16_wfByPath() throws Exception {
     java.net.URL url = getClass().getResource("valid_count-lines16-wf.cwl");
     java.nio.file.Path resPath = java.nio.file.Paths.get(url.toURI());
     RootLoader.loadDocument(resPath);
   }
 
-  @org.junit.Test
+  @org.junit.Test(expected = NullPointerException.class)
   public void testvalid_count_lines16_wfByMap() throws Exception {
     java.net.URL url = getClass().getResource("valid_count-lines16-wf.cwl");
     java.nio.file.Path resPath = java.nio.file.Paths.get(url.toURI());
@@ -3594,7 +3594,7 @@ public class ExamplesTest {
     doc = (java.util.Map<String, Object>) YamlUtils.mapFromString(yaml);
     RootLoader.loadDocument(doc, url.toString());
   }
-  @org.junit.Test
+  @org.junit.Test(expected = NullPointerException.class)
   public void testvalid_count_lines10_wfByString() throws Exception {
     String path = java.nio.file.Paths.get(".").toAbsolutePath().normalize().toString();
     String baseUri = Uris.fileUri(path) + "/";
@@ -3604,14 +3604,14 @@ public class ExamplesTest {
     RootLoader.loadDocument(yaml, baseUri);
   }
 
-  @org.junit.Test
+  @org.junit.Test(expected = NullPointerException.class)
   public void testvalid_count_lines10_wfByPath() throws Exception {
     java.net.URL url = getClass().getResource("valid_count-lines10-wf.cwl");
     java.nio.file.Path resPath = java.nio.file.Paths.get(url.toURI());
     RootLoader.loadDocument(resPath);
   }
 
-  @org.junit.Test
+  @org.junit.Test(expected = NullPointerException.class)
   public void testvalid_count_lines10_wfByMap() throws Exception {
     java.net.URL url = getClass().getResource("valid_count-lines10-wf.cwl");
     java.nio.file.Path resPath = java.nio.file.Paths.get(url.toURI());
@@ -6532,7 +6532,7 @@ public class ExamplesTest {
     doc = (java.util.Map<String, Object>) YamlUtils.mapFromString(yaml);
     RootLoader.loadDocument(doc, url.toString());
   }
-  @org.junit.Test
+  @org.junit.Test(expected = NullPointerException.class)
   public void testvalid_count_lines18_wfByString() throws Exception {
     String path = java.nio.file.Paths.get(".").toAbsolutePath().normalize().toString();
     String baseUri = Uris.fileUri(path) + "/";
@@ -6542,14 +6542,14 @@ public class ExamplesTest {
     RootLoader.loadDocument(yaml, baseUri);
   }
 
-  @org.junit.Test
+  @org.junit.Test(expected = NullPointerException.class)
   public void testvalid_count_lines18_wfByPath() throws Exception {
     java.net.URL url = getClass().getResource("valid_count-lines18-wf.cwl");
     java.nio.file.Path resPath = java.nio.file.Paths.get(url.toURI());
     RootLoader.loadDocument(resPath);
   }
 
-  @org.junit.Test
+  @org.junit.Test(expected = NullPointerException.class)
   public void testvalid_count_lines18_wfByMap() throws Exception {
     java.net.URL url = getClass().getResource("valid_count-lines18-wf.cwl");
     java.nio.file.Path resPath = java.nio.file.Paths.get(url.toURI());
@@ -6714,7 +6714,7 @@ public class ExamplesTest {
     doc = (java.util.Map<String, Object>) YamlUtils.mapFromString(yaml);
     RootLoader.loadDocument(doc, url.toString());
   }
-  @org.junit.Test
+  @org.junit.Test(expected = NullPointerException.class)
   public void testvalid_count_lines15_wfByString() throws Exception {
     String path = java.nio.file.Paths.get(".").toAbsolutePath().normalize().toString();
     String baseUri = Uris.fileUri(path) + "/";
@@ -6724,14 +6724,14 @@ public class ExamplesTest {
     RootLoader.loadDocument(yaml, baseUri);
   }
 
-  @org.junit.Test
+  @org.junit.Test(expected = NullPointerException.class)
   public void testvalid_count_lines15_wfByPath() throws Exception {
     java.net.URL url = getClass().getResource("valid_count-lines15-wf.cwl");
     java.nio.file.Path resPath = java.nio.file.Paths.get(url.toURI());
     RootLoader.loadDocument(resPath);
   }
 
-  @org.junit.Test
+  @org.junit.Test(expected = NullPointerException.class)
   public void testvalid_count_lines15_wfByMap() throws Exception {
     java.net.URL url = getClass().getResource("valid_count-lines15-wf.cwl");
     java.nio.file.Path resPath = java.nio.file.Paths.get(url.toURI());

--- a/src/test/java/org/w3id/cwl/cwl1_2/utils/RequirementsClassTest.java
+++ b/src/test/java/org/w3id/cwl/cwl1_2/utils/RequirementsClassTest.java
@@ -23,7 +23,7 @@ public class RequirementsClassTest {
 
 	@Test
 	public void className() {
-		Assert.assertEquals(doc.getClass().getSimpleName(), "CommandLineToolImpl");
+		Assert.assertEquals("CommandLineToolImpl", doc.getClass().getSimpleName());
 	}
 
 	@Test
@@ -38,7 +38,7 @@ public class RequirementsClassTest {
 		java.util.Optional<java.util.List<Object>> hints = doc.getHints();
 		Assert.assertTrue(hints.isPresent());
 		java.util.List<Object> hintList = hints.get();
-		Assert.assertEquals(hintList.size(), 1);
+		Assert.assertEquals(1, hintList.size());
 	}
 
 	@Test
@@ -46,10 +46,10 @@ public class RequirementsClassTest {
 		java.util.Optional<java.util.List<Object>> reqs = doc.getRequirements();
 		Assert.assertTrue(reqs.isPresent());
 		java.util.List<Object> reqList = reqs.get();
-		Assert.assertEquals(reqList.size(), 2);
+		Assert.assertEquals(2, reqList.size());
 		InlineJavascriptRequirement reqOne = (InlineJavascriptRequirement) reqList.get(0);
-		Assert.assertEquals(reqOne.getClass().getSimpleName(), "InlineJavascriptRequirementImpl");
-		Assert.assertNotEquals(reqList.get(1).getClass().getSimpleName(), "InlineJavascriptRequirementImpl");
+		Assert.assertEquals("InlineJavascriptRequirementImpl", reqOne.getClass().getSimpleName());
+		Assert.assertNotEquals("InlineJavascriptRequirementImpl", reqList.get(1).getClass().getSimpleName());
 	}
 
 }

--- a/src/test/java/org/w3id/cwl/cwl1_2/utils/WorkflowClassTest.java
+++ b/src/test/java/org/w3id/cwl/cwl1_2/utils/WorkflowClassTest.java
@@ -1,0 +1,36 @@
+package org.w3id.cwl.cwl1_2.utils;
+
+import org.w3id.cwl.cwl1_2.Process;
+import org.w3id.cwl.cwl1_2.SchemaDefRequirement;
+import org.w3id.cwl.cwl1_2.CWLVersion;
+import org.w3id.cwl.cwl1_2.InlineJavascriptRequirement;
+import org.w3id.cwl.cwl1_2.InputRecordSchema;
+
+import java.net.URISyntaxException;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class WorkflowClassTest {
+	Process doc;
+	
+	public WorkflowClassTest() throws URISyntaxException {
+		super();
+		this.doc = (Process) RootLoader
+				.loadDocument(java.nio.file.Paths.get(getClass().getResource("valid_count-lines1-wf.cwl").toURI()));
+	}
+
+	@Test
+	public void className() {
+		Assert.assertEquals("WorkflowImpl", doc.getClass().getSimpleName());
+	}
+
+	@Test
+	public void version() {
+		java.util.Optional<CWLVersion> version = doc.getCwlVersion();
+		Assert.assertTrue(version.isPresent());
+		Assert.assertEquals(CWLVersion.V1_2, version.get());
+	}
+
+}


### PR DESCRIPTION
`class: Workflow` now results in a `WorkflowImpl` java class. Fixes #37 

This fix surfaces the fact that embedded subworkflows are not yet working. 

Builds upon https://github.com/common-workflow-language/cwl-v1.2/pull/62/commits/696243fe16d3aceadd7f42bc9b21e121bfb955fc