### PR TITLE
scope check: chop off the correct end of the fragment

### DIFF
--- a/src/main/java/org/w3id/cwl/cwl1_2/utils/LoadingOptions.java
+++ b/src/main/java/org/w3id/cwl/cwl1_2/utils/LoadingOptions.java
@@ -94,7 +94,7 @@ public class LoadingOptions {
       final ArrayList<String> sp = new ArrayList(Arrays.asList(splitbase.fragment.split("/")));
       int n = scopedRef;
       while (n > 0 && sp.size() > 0) {
-        sp.remove(0);
+        sp.remove(sp.size()-1);
         n -= 1;
       }
       sp.add(url);

--- a/src/test/java/org/w3id/cwl/cwl1_2/utils/PackedWorkflowClassTest.java
+++ b/src/test/java/org/w3id/cwl/cwl1_2/utils/PackedWorkflowClassTest.java
@@ -1,0 +1,46 @@
+package org.w3id.cwl.cwl1_2.utils;
+
+import org.w3id.cwl.cwl1_2.Process;
+import org.w3id.cwl.cwl1_2.SchemaDefRequirement;
+import org.w3id.cwl.cwl1_2.Workflow;
+import org.w3id.cwl.cwl1_2.WorkflowStep;
+import org.w3id.cwl.cwl1_2.WorkflowStepInput;
+import org.w3id.cwl.cwl1_2.CWLVersion;
+import org.w3id.cwl.cwl1_2.InlineJavascriptRequirement;
+import org.w3id.cwl.cwl1_2.InputRecordSchema;
+
+import java.net.URISyntaxException;
+import java.nio.file.Paths;
+import java.util.List;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class PackedWorkflowClassTest {
+	List<Process> doc;
+	
+	@SuppressWarnings("unchecked")
+	public PackedWorkflowClassTest() throws URISyntaxException {
+		super();
+		this.doc = (List<Process>) RootLoader
+				.loadDocument(Paths.get(getClass().getResource("valid_scatter-wf4.cwl").toURI()));
+	}
+
+	@Test
+	public void className() {
+		Workflow workflow = (Workflow) doc.get(1);
+		Assert.assertEquals("WorkflowImpl", workflow.getClass().getSimpleName());
+	}
+	
+	@Test
+	public void workflowStepInputSources() {
+		Workflow workflow = (Workflow) doc.get(1);
+		String workflow_id = workflow.getId().get();
+		WorkflowStep step1 = (WorkflowStep) workflow.getSteps().get(0);
+		List<Object> inputs = step1.getIn();
+		WorkflowStepInput step1_input1 = (WorkflowStepInput) inputs.get(0);
+		Assert.assertEquals(workflow_id + "/step1/echo_in1", step1_input1.getId().get());
+		Assert.assertEquals(workflow_id + "/inp1", step1_input1.getSource());
+	}
+
+}


### PR DESCRIPTION
Fixes #61 